### PR TITLE
remove console.log calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,11 @@ module.exports = function (version, hash, getKey, minSlots) {
       if(!buffer)
         initialize(minSlots || 65536)
       else {
-        console.log("RELOAD", buffer.readUInt32BE(0), buffer.readUInt32BE(4))
         //check that version is correct
         if(version !== buffer.readUInt32BE(0))
           return initialize(minSlots || 65536)
         else {
           mt = Multi(HT, buffer.slice(8))
-          console.log("RELOADED", buffer.readUInt32BE(4))
           since.set(buffer.readUInt32BE(4)-1)
         }
       }

--- a/multi.js
+++ b/multi.js
@@ -12,7 +12,6 @@ module.exports = function (createHashtable, tables) {
     while(start < buffer.length) {
       var slots = buffer.readUInt32BE(start)
       var end = start + 8 + slots * 4
-      console.log(start, end, slots, buffer.slice(start, end).length)
       tables.push(createHashtable(buffer.slice(start, end)))
       start = end
     }


### PR DESCRIPTION
These logs have been showing up as unwanted artifacts in many different usages of scuttlebot:

```
RELOAD 2 352918490
0 262152 65536 262152
262152 786448 131072 524296
786448 1835032 262144 1048584
1835032 3932192 524288 2097160
RELOADED 352918490
```

And they come from flumeview-hashtable. As sbot evolves, it should have better CLI options for how verbose the logging should be, as well as allowing completely silent stdout.