### PR TITLE
Pass `seq` through each layer of abstraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,10 +93,10 @@ module.exports = function (version, hash, getKey, minSlots) {
       },
       get: function (key, cb) {
         var called = false
-        mt.get(key, function (err, value) {
+        mt.get(key, function (err, value, seq) {
           if(called) throw new Error('called already!')
           called = true
-          cb(err, value)
+          cb(err, value, seq)
         })
       },
       destroy: function (cb) {

--- a/multi.js
+++ b/multi.js
@@ -29,8 +29,8 @@ module.exports = function (createHashtable, tables) {
 
     get: function (key, cb) {
       ;(function next (i) {
-        tables[i].get(key, function (err, value) {
-          if(value) cb(null, value)
+        tables[i].get(key, function (err, value, seq) {
+          if(value) cb(null, value, seq)
           else if(i) next(i-1)
           else cb(err)
         })

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,0 +1,31 @@
+const Log = require('flumelog-offset')
+const Flume = require('flumedb')
+const crypto = require('crypto')
+const test = require('tape')
+
+function hash (v) {
+  return crypto.createHash('sha256')
+    .update(v.toString())
+    .digest().readUInt32BE(0)
+}
+
+const db = Flume(
+  Log(
+    '/tmp/test-flumeview-hashtable-' + String(Math.random()) + '/log.offset',
+    {blockSize: 1024, codec: require('flumecodec/json')}
+  ))
+  .use('index', require('../')(1, hash))
+
+test('no errors, correct value and sequence number', (t) => {
+  const item = { key: 'foo', value: 'bar' }
+
+  db.append(item, function (err) {
+    t.error(err)
+    db.index.get(item.key, function (err, val, seq) {
+      t.error(err)
+      t.deepEqual(val, item)
+      t.equal(seq, 1)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Previously we were passing `seq` through only one layer of abstraction,
but it doesn't look like it was actually making it out of `get()`. This
adds a simple full-stack test for the correct behavior and adds a fix
to ensure that the test passes.